### PR TITLE
Changes maxVersion number to be accepted with thunderbird 8.0.*

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -15,7 +15,7 @@
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> <!-- Thunderbird -->
         <em:minVersion>2.0</em:minVersion>
-        <em:maxVersion>7.0.*</em:maxVersion>
+        <em:maxVersion>8.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     


### PR DESCRIPTION
Allows the plugin to be installed in thunderbird 8. Still works.
